### PR TITLE
TeaVM Build Prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
                 <version>3.6.0</version>
                 <executions>
                     <execution>
+                        <id>webserver</id>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -32,14 +33,64 @@
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>
+                    <!-- TemplateRenderer JAR - run manually with mvn assembly:single@template-renderer -->
+                    <execution>
+                        <id>template-renderer</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>mtmc.web.teavm.TemplateRenderer</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <finalName>mtmc-template-renderer</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+
                 </executions>
             </plugin>
+            
+            <!-- TeaVM Plugin for Java to JavaScript compilation -->
+            <plugin>
+                <groupId>org.teavm</groupId>
+                <artifactId>teavm-maven-plugin</artifactId>
+                <version>${teavm.version}</version>
+                <executions>
+                    <!-- WebWorker execution -->
+                    <execution>
+                        <id>webworker</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>mtmc.web.teavm.WebWorker</mainClass>
+                            <target>javascript</target>
+                            <targetDirectory>${project.basedir}/dist/js</targetDirectory>
+                            <targetFileName>mtmc.js</targetFileName>
+                            <jsModuleType>NONE</jsModuleType>
+                            <debugInformationGenerated>true</debugInformationGenerated>
+                            <sourceMapsGenerated>true</sourceMapsGenerated>
+                            <minifying>false</minifying>
+                            <optimizationLevel>SIMPLE</optimizationLevel>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <teavm.version>0.12.3</teavm.version>
     </properties>
     <dependencies>
         <dependency>
@@ -72,6 +123,30 @@
             <groupId>org.webjars.npm</groupId>
             <artifactId>monaco-editor</artifactId>
             <version>0.52.2</version>
+        </dependency>
+        
+        <!-- TeaVM Class Library for JavaScript compilation -->
+        <dependency>
+            <groupId>org.teavm</groupId>
+            <artifactId>teavm-classlib</artifactId>
+            <version>${teavm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- TeaVM JavaScript Object Interop -->
+        <dependency>
+            <groupId>org.teavm</groupId>
+            <artifactId>teavm-jso</artifactId>
+            <version>${teavm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- TeaVM JavaScript Interop APIs -->
+        <dependency>
+            <groupId>org.teavm</groupId>
+            <artifactId>teavm-jso-apis</artifactId>
+            <version>${teavm.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e  # Exit on any error
+
+# Color function for green text
+green() {
+    echo -e "\033[32m$1\033[0m"
+}
+
+# Find project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# Clean old dist
+rm -rf dist/*
+
+# Make dist dirs
+mkdir -p dist/
+mkdir -p dist/js/
+mkdir -p dist/css/
+mkdir -p dist/img/
+mkdir -p dist/assets/
+
+# Build everything including assembled JAR
+green "Normal build"
+mvn clean package -DskipTests -q
+
+# Extract WebJars from the assembled JAR
+green "Extract and move webjars"
+
+jar xf ./target/mtmc.jar META-INF/resources/webjars/
+
+# Move webjars to the root level (so /webjars/monaco-editor/... paths work)
+mv META-INF/resources/webjars ./dist/
+rm -rf META-INF
+
+# Build TemplateRenderer JAR and run it (need to compile first since clean was run)
+green "Build TemplateRenderer"
+mvn compile assembly:single@template-renderer -q
+
+green "Render the Template"
+java -jar target/mtmc-template-renderer.jar dist
+
+# Build TeaVM WebWorker
+green "Build WebWorker"
+mvn org.teavm:teavm-maven-plugin:compile@webworker -q
+
+# Copy public assets
+cp -r src/main/resources/public/* dist/
+cp -r src/main/resources/disk.zip dist/
+

--- a/src/main/java/mtmc/os/fs/FileSystem.java
+++ b/src/main/java/mtmc/os/fs/FileSystem.java
@@ -13,7 +13,7 @@ import java.util.zip.ZipInputStream;
 import mtmc.emulator.MonTanaMiniComputer;
 
 public class FileSystem {
-    private String cwd = "/home";
+    private String cwd = "/";
     private MonTanaMiniComputer computer;
     static final Path DISK_PATH = Path.of(System.getProperty("user.dir"), "disk").toAbsolutePath();
     

--- a/src/main/java/mtmc/os/fs/FileSystem.java
+++ b/src/main/java/mtmc/os/fs/FileSystem.java
@@ -13,7 +13,7 @@ import java.util.zip.ZipInputStream;
 import mtmc.emulator.MonTanaMiniComputer;
 
 public class FileSystem {
-    private String cwd = "/";
+    private String cwd = "/home";
     private MonTanaMiniComputer computer;
     static final Path DISK_PATH = Path.of(System.getProperty("user.dir"), "disk").toAbsolutePath();
     

--- a/src/main/java/mtmc/web/teavm/TemplateRenderer.java
+++ b/src/main/java/mtmc/web/teavm/TemplateRenderer.java
@@ -1,0 +1,67 @@
+package mtmc.web.teavm;
+
+import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+import mtmc.emulator.MonTanaMiniComputer;
+import mtmc.web.MTMCWebView;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Template renderer to generate full index.html for TeaVM build
+ */
+public class TemplateRenderer {
+    
+    public static void main(String[] args) {
+        try {
+            String outputDir = args.length > 0 ? args[0] : "dist";
+            renderTemplates(outputDir);
+        } catch (Exception e) {
+            System.err.println("Failed to render templates: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+    
+    private static void renderTemplates(String outputDir) throws IOException {
+        // Create a mock computer with default state for template rendering
+        MonTanaMiniComputer mockComputer = new MonTanaMiniComputer();
+        MTMCWebView computerView = new MTMCWebView(mockComputer);
+        
+        // Create Pebble engine (same config as WebServer)
+        PebbleEngine engine = new PebbleEngine.Builder().cacheActive(true).build();
+        
+        // Render the main template with tea environment
+        String html = render(engine, "templates/index.html", computerView, "tea");
+        
+        // Ensure output directory exists
+        Path outputPath = Paths.get(outputDir);
+        if (!Files.exists(outputPath)) {
+            Files.createDirectories(outputPath);
+        }
+        
+        // Write the rendered HTML
+        Path indexPath = outputPath.resolve("index.html");
+        Files.write(indexPath, html.getBytes(StandardCharsets.UTF_8));
+        
+    }
+    
+    private static String render(PebbleEngine engine, String templateName, MTMCWebView computerView, String environment) {
+        PebbleTemplate template = engine.getTemplate(templateName);
+        Writer writer = new StringWriter();
+        try {
+            template.evaluate(writer, Map.of("computer", computerView, "environment", environment));
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+}

--- a/src/main/java/mtmc/web/teavm/WebWorker.java
+++ b/src/main/java/mtmc/web/teavm/WebWorker.java
@@ -1,0 +1,48 @@
+package mtmc.web.teavm;
+
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.JSExport;
+
+public class WebWorker {
+    
+    private static int pingCounter = 0;
+    
+    public static void main(String[] args) {
+        setupMessageListener();
+        // Example: Send an update:execution event after initialization
+        sendEvent("update:execution", "<div>Worker initialized</div>");
+    }
+    
+    @JSExport
+    public static void handleMessage(String type, String payload) {
+        if ("ping".equals(type)) {
+            pingCounter++;
+            sendMessage("pong", "Pong #" + pingCounter + " - " + payload);
+        } else {
+            System.out.println("WebWorker got unhandled message: " + type + ", " + payload);
+        }
+    }
+    
+    /**
+     * Send SSE to the frontend
+     * Usage: WebWorker.sendEvent("update:execution", htmlContent);
+     */
+    public static void sendEvent(String eventType, String data) {
+        sendMessage("sse:" + eventType, data);
+    }
+    
+    public static void sendMessage(String type, String payload) {
+        postMessage(createMessage(type, payload));
+    }
+    
+    @JSBody(params = { "message" }, script = "postMessage(message);")
+    private static native void postMessage(JSObject message);
+    
+    @JSBody(params = { "type", "payload" }, script = "return { type: type, payload: payload };")
+    private static native JSObject createMessage(String type, String payload);
+    
+    @JSBody(script = "self.addEventListener('message', function(e) { handleMessage(e.data.type || '', e.data.payload || ''); });")
+    private static native void setupMessageListener();
+}
+

--- a/src/main/resources/public/js/mtmc-worker.js
+++ b/src/main/resources/public/js/mtmc-worker.js
@@ -1,0 +1,3 @@
+importScripts('/js/mtmc.js');
+main([]);
+

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,6 +4,9 @@
     <meta name="viewport" content="minimal-ui, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    {% if environment %}
+    <meta name="mtmc-environment" content="{{ environment }}">
+    {% endif %}
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" data-name="vs/editor/editor.main" href="webjars/monaco-editor/0.52.2/min/vs/editor/editor.main.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
Initial scaffolding for a sustainable web port using TeaVM. #17 

* Builds a TeaVM artifact from the Java codebase, currently no MTMC functionality just I/O setup
* Renders the full `index.html` from templates and copies over needed files including `disk.zip` and `webjars`
* Environment detection for `main.js`: `window.tea = true`
* If `window.tea` is true, `main.js` wraps `fetch` and `EventSource` to hit the TeaVM artifact instead of a backend url.
* If not `window.tea`, behavior is unchanged.

## Instructions
To run the TeaVM build, run `./scripts/build-web.sh`. After that, the webfiles can be found in `./dist`. In my dev I've just been running `python3 -m http.server` in the `./dist` dir and refreshing after running the build script.

## Next Steps
The precise way of wrapping `fetch` and `EventSource` may need changes, this is just a starting point. fixi.js is still attempting to fetch a backend in the tea build.

To add real MTMC functionality to the TeaVM artifact, the `WebWorker.java` entry point needs to incorporate and reuse the WebServer api on a parallel code path that does not hit real file IO, `awt`, or real http server dependencies. IIRC Threads will not break the build, but the resulting artifact will be single threaded, which means some rearchitecting may be needed for simultaneous IO and MTMC computation in the TeaVM UI.

There are also various implicit backend requests such as the `<img src="/display">` for the display image, which would need refactoring.