### PR TITLE
Fix BP name to base pointer

### DIFF
--- a/docs/MTMC_ASSEMBLY.md
+++ b/docs/MTMC_ASSEMBLY.md
@@ -41,7 +41,7 @@ There are 16 user-facing registers usable by name in assembly:
 | 11    | `ra`   | return address register, holds the return address for a function call |
 | 12    | `fp`   | frame pointer, points to the top of the current function frame        |
 | 13    | `sp`   | stack pointer, points to the bottom of the current function frame     |
-| 14    | `bp`   | break pointer, points to the top of the current heap space            |
+| 14    | `bp`   | base pointer, points to the top of the current heap space             |
 | 15    | `pc`   | program counter, points to the next instruction to execute            |
 
 
@@ -105,7 +105,7 @@ Labels must be the first token on a line and must end with a colon.  If you wish
 
 Note that strings will be implicitly zero terminated.
 
-The above data will be placed after the code segment in memory, in a data segment.  The break pointer will point to the next memory cell after the data segment.
+The above data will be placed after the code segment in memory, in a data segment.  The base pointer will point to the next memory cell after the data segment.
 
 Also note that the `#` character can be used for line comments.
 

--- a/docs/MTMC_SPECIFICATION.md
+++ b/docs/MTMC_SPECIFICATION.md
@@ -50,7 +50,7 @@ The MTMC has a total of 16 user-facing register. They are outlined below.
 | 11    | `ra` | return address register, holds the return address for a function call |
 | 12    | `fp` | frame pointer, points to the top of the current function frame        |
 | 13    | `sp` | stack pointer, points to the bottom of the current function frame     |
-| 14    | `bp` | break pointer, points to the top of the current heap space            |
+| 14    | `bp` | base pointer, points to the top of the current heap space             |
 | 15    | `pc` | program counter, points to the next instruction to execute            |
 
 In addition to these registers, there are the following non-user facing registers:

--- a/src/main/java/mtmc/emulator/Register.java
+++ b/src/main/java/mtmc/emulator/Register.java
@@ -17,7 +17,7 @@ public enum Register {
     RA,  // return address
     FP, // frame pointer
     SP, // stack pointer
-    BP, // break pointer
+    BP, // base pointer
     PC,
 
     //=== non-user-facing registers


### PR DESCRIPTION
The BP register is traditionally called "base pointer". I assume calling it "break pointer" was a misspelling.

One line already called it properly here
https://github.com/msu/mtmc/blob/265a91acab81e1277d7ad0aa23a249321a7d51c3/src/main/java/mtmc/emulator/MonTanaMiniComputer.java#L80-L81