### PR TITLE
Add a script to regenerate the manifest automatically

### DIFF
--- a/build_disk_manifest.sh
+++ b/build_disk_manifest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script build disk/manifest.json from the list of files located in the ./disk/
+# directory.
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <new version (Major.Minor.Patch)>" >&2
+    exit 1
+fi
+
+version="$1"
+disk_dir="./disk"
+manifest="$disk_dir/manifest.json"
+
+first_item=true
+
+echo "{" > "$manifest"
+echo "  \"_version\": \"$version\"," >> "$manifest"
+
+while IFS= read -r -d '' file; do
+    filename=$(basename "$file")
+    if [[ "$filename" == manifest.json* ]]; then
+        continue
+    fi
+    if [ "$first_item" = true ]; then
+      first_item=false
+    else
+      echo "," >> "$manifest"
+    fi
+    file_loc="${file#$disk_dir}"
+    printf '  "%s": "%s"'  "$file_loc" "${file_loc#/}" >> "$manifest"
+done < <(find "$disk_dir" -type f -print0 | sort -z)
+
+echo "" >> "$manifest"
+echo "}" >> "$manifest"


### PR DESCRIPTION
This script rebuild the manifest based on the content of the disk/ directory. The files under disk are listed in alphabetical order. The version has to be specified as a parameter to the script.

The issue listed in Issue #1 was due to a bad manifest and was fixed in PR #4. This PR adds a script so the manifest can be regenerated automatically in the future.